### PR TITLE
Disable anyfold in neovim terminal

### DIFF
--- a/autoload/anyfold.vim
+++ b/autoload/anyfold.vim
@@ -20,7 +20,7 @@ function! anyfold#init() abort
         let b:anyfold_initialised = 1
     endif
 
-    let b:anyfold_disable = &diff
+    let b:anyfold_disable = &diff || (&buftype ==# "terminal")
     if b:anyfold_disable
         return
     endif


### PR DESCRIPTION
It should resolve #8 

Terminal buffer differentiation method taken from [here](https://github.com/neovim/neovim/issues/3712).