### PR TITLE
Fix broken link in comment in autoload/anyfold.vim

### DIFF
--- a/autoload/anyfold.vim
+++ b/autoload/anyfold.vim
@@ -599,7 +599,7 @@ endfunction
 "----------------------------------------------------------------------------/
 " Improved fold display
 " Inspired by example code by Greg Sexton
-" http://www.gregsexton.org/2011/03/improving-the-text-displayed-in-a-fold/
+" http://gregsexton.org/2011/03/27/improving-the-text-displayed-in-a-vim-fold.html
 "----------------------------------------------------------------------------/
 function! MinimalFoldText() abort
     let fs = v:foldstart


### PR DESCRIPTION
This fixes the same link as in 3b366d41d70636496a51fd72f9e8348324ea6395, in a different file.