### PR TITLE
:AnyFoldActivate command with bang allows for repeat activation

### DIFF
--- a/autoload/anyfold.vim
+++ b/autoload/anyfold.vim
@@ -1,33 +1,41 @@
 "----------------------------------------------------------------------------/
 " Initialization: Activation of requested features
 "----------------------------------------------------------------------------/
-function! anyfold#init(force) abort
-
-    if exists("g:anyfold_activate")
-        let b:anyfold_activate = g:anyfold_activate
-    endif
-
-    if !a:force
-        if !exists("b:anyfold_activate")
-            return
-        elseif !b:anyfold_activate
-            return
+function! anyfold#init(force, bang) abort
+    let anyfold_reinitializing = 0
+    if a:bang == 1
+        " skip double initialization guards
+        if exists("b:anyfold_initialised")
+            let anyfold_reinitializing = 1
         endif
-    endif
-
-    " make sure initialisation only happens once
-    if exists("b:anyfold_initialised")
-        return
-    else
         let b:anyfold_initialised = 1
-    endif
+    else
+        if exists("g:anyfold_activate")
+            let b:anyfold_activate = g:anyfold_activate
+        endif
 
-    if exists("b:anyfold_activate")
-        echoerr "anyfold: 'let anyfold_activate=1' is deprecated, replace by command ':AnyFoldActivate' (see ':h AnyFoldActivate')"
-    endif
+        if !a:force
+            if !exists("b:anyfold_activate")
+                return
+            elseif !b:anyfold_activate
+                return
+            endif
+        endif
 
-    if exists("b:AnyFoldActivate") || exists("g:AnyFoldActivate")
-        echoerr "anyfold: 'let AnyFoldActivate=1' does not work, ':AnyFoldActivate' is a command! (see ':h AnyFoldActivate')"
+        " make sure initialisation only happens once
+        if exists("b:anyfold_initialised")
+            return
+        else
+            let b:anyfold_initialised = 1
+        endif
+
+        if exists("b:anyfold_activate")
+            echoerr "anyfold: 'let anyfold_activate=1' is deprecated, replace by command ':AnyFoldActivate' (see ':h AnyFoldActivate')"
+        endif
+
+        if exists("b:AnyFoldActivate") || exists("g:AnyFoldActivate")
+            echoerr "anyfold: 'let AnyFoldActivate=1' does not work, ':AnyFoldActivate' is a command! (see ':h AnyFoldActivate')"
+        endif
     endif
 
     if s:AnyfoldDisable()
@@ -67,7 +75,9 @@ function! anyfold#init(force) abort
     endif
 
     " calculate indents for first time
-    call s:InitIndentList()
+    if !anyfold_reinitializing
+        call s:InitIndentList()
+    endif
 
     " folds are always updated when buffer has changed
     autocmd TextChanged,InsertLeave <buffer> call s:ReloadFolds()

--- a/plugin/anyfold.vim
+++ b/plugin/anyfold.vim
@@ -3,8 +3,9 @@ if exists("b:loaded_anyfold")
 endif
 let b:loaded_anyfold = 1
 
-command! AnyFoldActivate call anyfold#init(1)
+command! -bang AnyFoldActivate call anyfold#init(1, '<bang>' == '!')
 
 " deprecated initialization using anyfold_activate variable
 " still works but echoes a warning
-au BufNewFile,BufRead * call anyfold#init(0)
+au BufNewFile,BufRead * call anyfold#init(0, "n/a")
+


### PR DESCRIPTION

Sometimes another foldexpr or related mappings might be useful. It would
be nice to restore AnyFold after this. Previously, the double
initialization guard in the #init function prevented in. This patch
allows the command to to take a bang (``AnyFoldActivate!``) which
reloads the foldexpr and remaps keys etc.