### PR TITLE
Adds fillchar support to anyfold

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Option | Values | Default value |  Description
 `anyfold_fold_toplevel` | 0, 1 | 0 | Fold subsequent unindented lines
 `anyfold_fold_size_str` | string | '%s lines' | Format of fold size string in minimalistic display
 `anyfold_fold_level_str` | string | ' + ' | Format of fold level string in minimalistic display
+anyfold_fold_fillchar  | string | ' ' | Fold fill character
 
 ## Complementary plugins
 

--- a/autoload/anyfold.vim
+++ b/autoload/anyfold.vim
@@ -45,6 +45,7 @@ function! anyfold#init(force) abort
                     \ 'motion':                       1,
                     \ 'debug':                        0,
                     \ 'fold_size_str':           '%s lines',
+                    \ 'fold_fillchar':              ' ',
                     \ 'fold_level_str':             ' + ',
                     \ }
         lockvar! g:_ANYFOLD_DEFAULTS
@@ -665,7 +666,7 @@ function! MinimalFoldText() abort
     let foldSizeStr = " " . substitute(g:anyfold_fold_size_str, "%s", string(foldSize), "g") . " "
     let foldLevelStr = repeat(g:anyfold_fold_level_str, v:foldlevel)
     let lineCount = line("$")
-    let expansionString = repeat(" ", w - strwidth(foldSizeStr.line.foldLevelStr))
+    let expansionString = repeat(g:anyfold_fold_fillchar, w - strwidth(foldSizeStr.line.foldLevelStr))
     return line . expansionString . foldSizeStr . foldLevelStr
 endfunction
 

--- a/autoload/anyfold.vim
+++ b/autoload/anyfold.vim
@@ -666,8 +666,8 @@ function! MinimalFoldText() abort
     let foldSizeStr = " " . substitute(g:anyfold_fold_size_str, "%s", string(foldSize), "g") . " "
     let foldLevelStr = repeat(g:anyfold_fold_level_str, v:foldlevel)
     let lineCount = line("$")
-    let expansionString = repeat(g:anyfold_fold_fillchar, w - strwidth(foldSizeStr.line.foldLevelStr))
-    return line . expansionString . foldSizeStr . foldLevelStr
+    let expansionString = repeat(g:anyfold_fold_fillchar, w - strwidth(foldSizeStr.line." ".foldLevelStr))
+    return line . " " . expansionString . foldSizeStr . foldLevelStr
 endfunction
 
 "----------------------------------------------------------------------------/

--- a/doc/anyfold.txt
+++ b/doc/anyfold.txt
@@ -102,6 +102,7 @@ g:anyfold_comments          | list of strings | ['comment', 'string'] |
 g:anyfold_fold_toplevel     | 0, 1            | 0 (= 'off') |
 g:anyfold_fold_size_str     | string          | '%s lines'  | Format of fold size string in minimalistic display
 g:anyfold_fold_level_str    | string          | ' + '       | Format of fold level string in minimalistic display
+g:anyfold_fold_fillchar     | string          | ' '         | Fold fill character
 
                                                                 *anyfoldLoaded*
 For expert configuration, anyfold triggers an |autocmd-event| `anyfoldLoaded`


### PR DESCRIPTION
This PR adds a new option called `anyfold_fold_fillchar`  to make the fill character configurable.

<img width="858" alt="Screenshot 2024-12-15 at 6 40 00 PM" src="https://github.com/user-attachments/assets/abfebfb9-1f32-4cef-b04e-4ebd2a959dc9" />

```vim
let g:anyfold_fold_fillchar='─'
```
<img width="865" alt="Screenshot 2024-12-15 at 6 39 19 PM" src="https://github.com/user-attachments/assets/c60ffa62-9047-47f2-9a82-242aa483ed21" />

